### PR TITLE
Quick and dirty support for cd in bash and zsh

### DIFF
--- a/rover.c
+++ b/rover.c
@@ -759,8 +759,9 @@ main(int argc, char *argv[])
     const char *key;
     DIR *d;
     EditStat edit_stat;
+    const char *save_cwd_file = NULL;
 
-    if (argc == 2) {
+    if (argc >= 2) {
         if (!strcmp(argv[1], "-v") || !strcmp(argv[1], "--version")) {
             printf("rover %s\n", RV_VERSION);
             return 0;
@@ -776,6 +777,10 @@ main(int argc, char *argv[])
                 "Rover homepage: <https://github.com/lecram/rover>.\n"
             );
             return 0;
+        } else if (argc > 2 && !strcmp(argv[1], "--save-cwd")) {
+            --argc; ++argv;
+            save_cwd_file = argv[1];
+            --argc; ++argv;
         }
     }
     init_term();
@@ -1097,5 +1102,10 @@ main(int argc, char *argv[])
         free_rows(&rover.rows, rover.nfiles);
     free_marks(&rover.marks);
     delwin(rover.window);
+    if (save_cwd_file != NULL) {
+        FILE *fd = fopen(save_cwd_file, "w");
+        fputs(rover.cwd[rover.tab], fd);
+        fclose(fd);
+    }
     return 0;
 }

--- a/rover.sh
+++ b/rover.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Based on ranger launcher.
+#
+# Usage: ". ./rover.sh [/path/to/rover]"
+
+tempfile="$(mktemp)"
+rover="${1:-rover}"
+test -z "$1" || shift
+"$rover" --save-cwd "$tempfile" "${@:-$(pwd)}"
+returnvalue=$?
+test -f "$tempfile" &&
+if [ "$(cat -- "$tempfile")" != "$(echo -n `pwd`)" ]; then
+    cd "$(cat "$tempfile")"
+fi
+rm -f -- "$tempfile"
+return $returnvalue


### PR DESCRIPTION
It should allow to change the working directory of the shell that started rover.

I've reused some code of ranger. It may be important from the licensing point of view (GPL), you may want to add a proper attribution if you want to keep that version.

The argv manipulation I'm doing may be troublesome if you decide you need `argv[0]` at some point -- I'm just incrementing the argv pointer while decrementing the argc counter. It's just a proof of concept.