### PR TITLE
Added removal option to the makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ LDLIBS=-lcurses
 PREFIX=/usr/local
 MANPREFIX=$(PREFIX)/man
 INSTALL=install -D
+UNINSTALL=rm
 
 all: rover
 
@@ -12,6 +13,10 @@ rover: rover.c config.h
 install: rover
 	$(INSTALL) rover $(DESTDIR)$(PREFIX)/bin/rover
 	$(INSTALL) rover.1 $(DESTDIR)$(MANPREFIX)/man1/rover.1
+
+uninstall: $(DESTDIR)$(PREFIX)/bin/rover
+	$(UNINSTALL) $(DESTDIR)$(PREFIX)/bin/rover
+	$(UNINSTALL) $(DESTDIR)$(MANPREFIX)/man1/rover.1
 
 clean:
 	$(RM) rover


### PR DESCRIPTION
Overall a good practice to have an option to uninstall in case someone either no longer has a use for `rover` or didn't configure the makefile correctly and installed it to the wrong location.