### PR TITLE
spawn a new screen window if in GNU screen

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -16,6 +16,9 @@ Note that it needs to be sourced directly from the shell.
 
 # Usage:
 #     . ./cdrover.sh [/path/to/rover]
+# it has to be sourced instead of being run
+# otherwise when it comes back from the sub shell, 
+# cd command does not make any difference in the original shell
 
 tempfile="$(mktemp 2> /dev/null || printf "/tmp/rover-cwd.%s" $$)"
 if [ $# -gt 0 ]; then
@@ -33,6 +36,18 @@ fi
 rm -f -- "$tempfile"
 return $returnvalue
 ```
+A better solution would be putting the following function in your `.bashrc`:
+
+```
+l () {
+  tempfile=$(mktemp 2> /dev/null)
+  rover --save-cwd "$tempfile" "$PWD" /some /other /directories
+  cd "$(cat $tempfile)"
+  rm -f $tempfile
+}
+```
+
+So that you can type `l` to launch rover to navigate to the desired path and `q` to quit rover but stay in the desired path.
 
 ## How to open files with appropriate applications?
 

--- a/config.h
+++ b/config.h
@@ -15,10 +15,10 @@
 #define RVK_HOME        "H"
 #define RVK_TARGET      "t"
 #define RVK_REFRESH     "r"
-#define RVK_SHELL       "^M"
+#define RVK_SHELL       "o"
 #define RVK_VIEW        " "
 #define RVK_EDIT        "e"
-#define RVK_OPEN        "o"
+#define RVK_OPEN        "^M"
 #define RVK_SEARCH      "/"
 #define RVK_TG_FILES    "f"
 #define RVK_TG_DIRS     "d"
@@ -38,12 +38,12 @@
 #define RVC_CWD         GREEN
 #define RVC_STATUS      CYAN
 #define RVC_BORDER      BLUE
-#define RVC_SCROLLBAR   CYAN
+#define RVC_SCROLLBAR   MAGENTA
 #define RVC_LINK        CYAN
 #define RVC_HIDDEN      YELLOW
 #define RVC_EXEC        GREEN
 #define RVC_REG         DEFAULT
-#define RVC_DIR         DEFAULT
+#define RVC_DIR         BLUE
 #define RVC_CHR         MAGENTA
 #define RVC_BLK         MAGENTA
 #define RVC_FIFO        BLUE
@@ -53,7 +53,7 @@
 #define RVC_MARKS       YELLOW
 
 /* Special symbols used by the TUI. See <curses.h> for available constants. */
-#define RVS_SCROLLBAR   ACS_CKBOARD
+#define RVS_SCROLLBAR   ACS_VLINE
 #define RVS_MARK        ACS_DIAMOND
 
 /* Prompt strings for line input. */

--- a/rover.c
+++ b/rover.c
@@ -1164,6 +1164,7 @@ main(int argc, char *argv[])
         } else if (!strcmp(key, RVK_REFRESH)) {
             reload();
         } else if (!strcmp(key, RVK_SHELL)) {
+          if (getenv("STY")==NULL) {
             program = getenv("SHELL");
             if (program) {
 #ifdef RV_SHELL
@@ -1173,6 +1174,10 @@ main(int argc, char *argv[])
 #endif
                 reload();
             }
+          } else { // in GNU screen
+            spawn((char *[]) {"screen", "-X", "chdir", CWD, NULL});
+            spawn((char *[]) {"screen", "1", NULL});
+          }
         } else if (!strcmp(key, RVK_VIEW)) {
             if (!rover.nfiles || S_ISDIR(EMODE(ESEL))) continue;
             if (open_with_env("PAGER", ENAME(ESEL)))


### PR DESCRIPTION
These 5 new lines would allow rover to open a new screen window starting with the directory where rover is displaying if rover is running in a GNU screen session. Note that the following setup in screenrc has to be commented out for chdir to take effect: shell -$SHELL.