### PR TITLE
Use install(1) again. Explicitly set file permissions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,10 @@ rover: rover.c config.h
 	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS) $(LDLIBS)
 
 install: rover
-	rm -f $(BINDIR)/rover
 	mkdir -p $(BINDIR)
-	cp rover $(BINDIR)/rover
+	install -m755 rover $(BINDIR)/rover
 	mkdir -p $(MANDIR)
-	cp rover.1 $(MANDIR)/rover.1
+	install -m644 rover.1 $(MANDIR)/rover.1
 
 uninstall: $(DESTDIR)$(PREFIX)/bin/rover
 	rm $(BINDIR)/rover


### PR DESCRIPTION
This is a more standard unix install target. It explicitly sets the file permissions to a sane value when installed. Additionally adding `rm` to the install target is weird and not necessary now.

One additional idea is to remove `mkdir` and just use `install`, but it may be better to use both given the reasons in the following link.

Source: https://unix.stackexchange.com/questions/104982/why-use-install-rather-than-cp-and-mkdir