### PR TITLE
Use 'rm -f' in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ install: rover
 	mkdir -p $(MANDIR)
 	cp rover.1 $(MANDIR)/rover.1
 
-uninstall: $(DESTDIR)$(PREFIX)/bin/rover
-	rm $(BINDIR)/rover
-	rm $(MANDIR)/rover.1
+uninstall:
+	rm -f $(BINDIR)/rover
+	rm -f $(MANDIR)/rover.1
 
 clean:
-	$(RM) rover
+	rm -f rover


### PR DESCRIPTION
There are a few minor changes here.

1. The uninstall target can be blank, it does not require rover to be actually installed and will error if its not where it should be.
2. Its better to use `rm -f` instead of `rm` because of the above reason. The files may not be there and it will error if they are not.
3. `$(RM)` does not seem to be posix and its better to use `rm -f` instead.

Sources:
https://stackoverflow.com/questions/40907379/makefile-syntax-what-is-rm
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html
https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html