### PR TITLE
Cancel copy operation if source and destination match

### DIFF
--- a/rover.c
+++ b/rover.c
@@ -874,6 +874,9 @@ static int cpyfile(const char *srcpath) {
 
     strcpy(dstpath, CWD);
     strcat(dstpath, srcpath + strlen(rover.marks.dirpath));
+    ret = strcmp(srcpath, dstpath);
+    if (!ret) return ret;
+
     ret = lstat(srcpath, &st);
     if (ret < 0) return ret;
     if (S_ISLNK(st.st_mode)) {


### PR DESCRIPTION
Test case: mark some files and hit `Shift-C` to copy them in the same path, files get truncated, 0 bytes. This could happen by accident (as it happened to me), and valuable information could be lost.

> Currently, when copying the marked files (and/or directories) in the
> same path as they are, they get truncated. Since there's no point
> to copy files/directories in the same path (without renaming them),
> cancel the operation when the source and destination match.