### PR TITLE
More standard install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-LDLIBS=-lncursesw
-PREFIX=/usr/local
-BINDIR=$(PREFIX)/bin
-MANDIR=$(PREFIX)/man
+LDLIBS := -lncursesw
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/man
 
 all: rover
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 LDLIBS=-lncursesw
 PREFIX=/usr/local
-MANPREFIX=$(PREFIX)/man
-BINDIR=$(DESTDIR)$(PREFIX)/bin
-MANDIR=$(DESTDIR)$(MANPREFIX)/man1
+BINDIR=$(PREFIX)/bin
+MANDIR=$(PREFIX)/man
 
 all: rover
 
@@ -10,15 +9,15 @@ rover: rover.c config.h
 	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS) $(LDLIBS)
 
 install: rover
-	rm -f $(BINDIR)/rover
-	mkdir -p $(BINDIR)
-	cp rover $(BINDIR)/rover
-	mkdir -p $(MANDIR)
-	cp rover.1 $(MANDIR)/rover.1
+	rm -f $(DESTDIR)$(BINDIR)/rover
+	mkdir -p $(DESTDIR)$(BINDIR)
+	cp rover $(DESTDIR)$(BINDIR)/rover
+	mkdir -p $(DESTDIR)$(MANDIR)/man1
+	cp rover.1 $(DESTDIR)$(MANDIR)/man1/rover.1
 
 uninstall:
-	rm -f $(BINDIR)/rover
-	rm -f $(MANDIR)/rover.1
+	rm -f $(DESTDIR)$(BINDIR)/rover
+	rm -f $(DESTDIR)$(MANDIR)/man1/rover.1
 
 clean:
 	rm -f rover

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 LDLIBS := -lncursesw
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
-MANDIR ?= $(PREFIX)/man
+DATAROOTDIR ?= $(PREFIX)/share
+DATADIR ?= $(DATAROOTDIR)
+MANDIR ?= $(DATADIR)/man
 
 all: rover
 


### PR DESCRIPTION
This changes the `Makefile` to have a more standard install process.

Changes:

* `$(DESTDIR)` is moved directly to the `install` and `uninstall` rules to avoid accidentally being lost by setting `MANDIR`, `BINDIR` or any other variable.
* `man1` is removed from the `MANDIR` and moved directly to the install rules as it should not be lost when setting `MANDIR` nor should it be overwritten by the user.
* Removes the non-standard and now useless `MANPREFIX`.
* Changes `MANDIR` to use FHS and GNU install paths which is by default `/usr/local/share/man` or `$(DATADIR)/man`.
* I also added `DATAROOTDIR` to follow the GNU standards, but it can be removed if preferred as its not strictly necessary in this case.
* Edit: Rebased to explicitly set variables with `?=` and `:=` as appropriate.

References:

https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html#usrsharemanManualPages
https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
https://www.gnu.org/software/make/manual/html_node/Setting.html 