### PR TITLE
Fix the build on gentoo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
-LDLIBS := -lncursesw
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 DATAROOTDIR ?= $(PREFIX)/share
 DATADIR ?= $(DATAROOTDIR)
 MANDIR ?= $(DATADIR)/man
 
+PKG_CONFIG ?= pkg-config
+
+CFLAGS_NCURSESW := `$(PKG_CONFIG) --cflags ncursesw`
+LIBS_NCURSESW := `$(PKG_CONFIG) --libs ncursesw`
+
 all: rover
 
 rover: rover.c config.h
-	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS) $(LDLIBS)
+	$(CC) $(CFLAGS) $(CFLAGS_NCURSESW) -o $@ $< $(LDFLAGS) $(LIBS_NCURSESW)
 
 install: rover
 	rm -f $(DESTDIR)$(BINDIR)/rover

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ DATAROOTDIR ?= $(PREFIX)/share
 DATADIR ?= $(DATAROOTDIR)
 MANDIR ?= $(DATADIR)/man
 
+CFLAGS ?= -O2
+
 PKG_CONFIG ?= pkg-config
 
 CFLAGS_NCURSESW := `$(PKG_CONFIG) --cflags ncursesw`

--- a/rover.c
+++ b/rover.c
@@ -1,4 +1,6 @@
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE       700
+#endif
 #define _XOPEN_SOURCE_EXTENDED
 #define _FILE_OFFSET_BITS   64
 


### PR DESCRIPTION
On gentoo the build fails.
```
$ make
cc  -o rover rover.c  -lncursesw
rover.c: In function ‘rover_get_wch’:
rover.c:316:19: warning: implicit declaration of function ‘get_wch’; did you mean ‘getch’? [-Wimplicit-function-declaration]
  316 |     while ((ret = get_wch(wch)) == (wint_t) ERR)
      |                   ^~~~~~~
      |                   getch
rover.c: In function ‘update_view’:
rover.c:458:5: warning: implicit declaration of function ‘mvaddnwstr’; did you mean ‘mvaddnstr’? [-Wimplicit-function-declaration]
  458 |     mvaddnwstr(0, 0, WBUF, COLS - 4 - numsize);
      |     ^~~~~~~~~~
      |     mvaddnstr
rover.c:514:9: warning: implicit declaration of function ‘mvwaddnwstr’; did you mean ‘mvwaddnstr’? [-Wimplicit-function-declaration]
  514 |         mvwaddnwstr(rover.window, i + 1, 2, WBUF, COLS - 4);
      |         ^~~~~~~~~~~
      |         mvwaddnstr
rover.c: In function ‘get_line_edit’:
rover.c:954:5: warning: implicit declaration of function ‘erasewchar’; did you mean ‘erasechar’? [-Wimplicit-function-declaration]
  954 |     erasewchar(&eraser);
      |     ^~~~~~~~~~
      |     erasechar
rover.c:955:5: warning: implicit declaration of function ‘killwchar’; did you mean ‘killchar’? [-Wimplicit-function-declaration]
  955 |     killwchar(&killer);
      |     ^~~~~~~~~
      |     killchar
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/ccYHhLoT.o: undefined reference to symbol 'keypad'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libtinfow.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:11: rover] Error 1
```
This can be fixed by linking with `-ltinfow` in addition to `-lncursesw` where a portable way to set this is to depend on pkgconfig. Additionally the implicit function declaration warnings can be silenced by the upstream ncursesw cflags, but this introduces a new warning which I silenced with a preprocessor check.
```
rover.c:2: warning: "_XOPEN_SOURCE" redefined
    2 | #define _XOPEN_SOURCE       700
      | 
<command-line>: note: this is the location of the previous definition
```
For reference here is the output of the pkgconf commands on gentoo.
```
$ pkgconf --cflags ncursesw
-D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -I/usr/include/ncursesw
```
```
$ pkgconf --libs ncursesw
-lncursesw -ltinfow
```
Note:

* I used legacy backquote shell substitution to retain compatibility with both `bmake` and `pmake`.
* This issue is not reproducible on Slackware, but the changes still work on Slackware.
* The `PKG_CONFIG` variable is standardized by at least autotools.
* The second commit adds a default of `-O2` to the `CFLAGS` variable. Like before this can be overridden by setting `CFLAGS` as a environment variable or make argument.